### PR TITLE
fixed cte naming issues

### DIFF
--- a/models/01_staging/manual/stg_manual__acquisition_orders.sql
+++ b/models/01_staging/manual/stg_manual__acquisition_orders.sql
@@ -1,26 +1,24 @@
 with
+    source as 
+    (
 
-source as (
+        select * from {{ source('manual','acq_orders') }}
 
-    select * from {{ source('manual','acq_orders') }}
+    ),
+    cleaned as
+    (
 
-),
-
-cleaned as
-
-(
-
-    select 
-        safe_cast(customer_id as int) as customer_id,
-        lower(trim(taxonomy_business_category_group)) as aquisition_channel
-    from source
-    
-)
+        select 
+            safe_cast(customer_id as int) as customer_id,
+            lower(trim(taxonomy_business_category_group)) as aquisition_channel,
+        from source
+        
+    )
 
 select 
     customer_id, 
-    aquisition_channel
+    aquisition_channel,
 from 
-    renamed
+    cleaned
 where 
     customer_id is not null

--- a/models/01_staging/manual/stg_manual__activity.sql
+++ b/models/01_staging/manual/stg_manual__activity.sql
@@ -1,9 +1,10 @@
-with
-
-    source as (select * from {{ source("manual", "activity") }}),
+with 
+    source as 
+    ( 
+        select * from {{ source("manual", "activity") }}
+    ),
 
     cleaned as
-
     (
 
         select
@@ -16,7 +17,7 @@ with
     )
 
 select customer_id, subscription_id, from_date, to_date
-from renamed
+from cleaned
 where customer_id is not null
     and subscription_id is not null
     and from_date is not null

--- a/models/01_staging/manual/stg_manual__customers.sql
+++ b/models/01_staging/manual/stg_manual__customers.sql
@@ -1,9 +1,10 @@
-with
-
-    source as (select * from {{ source("manual", "customers") }}),
+with 
+    source as 
+    (
+        select * from {{ source("manual", "customers") }}
+    ),
 
     cleaned as
-
     (
 
         select
@@ -14,5 +15,5 @@ with
     )
 
 select customer_id, country
-from renamed
+from cleaned
 where customer_id is not null


### PR DESCRIPTION
Fixed CTE naming issues - used `cleaned` consistently.
Reformatted staging SQL to make CTEs more legible